### PR TITLE
To Add UnRegister Drop Event when Page Unload

### DIFF
--- a/MauiPaint/DragDropExtensions.cs
+++ b/MauiPaint/DragDropExtensions.cs
@@ -19,12 +19,21 @@ public static class DragDropExtensions
 		DragDropHelper.UnRegisterDrag(view);
 	}
 
+#if MACCATALYST
 	public static void RegisterDrop(this IElement element, IMauiContext? mauiContext, Func<Stream, Task>? content)
 	{
 		ArgumentNullException.ThrowIfNull(mauiContext);
 		var view = element.ToPlatform(mauiContext);
 		DragDropHelper.RegisterDrop(view, content);
 	}
+#elif WINDOWS
+	public static void RegisterDrop(this IElement element, IMauiContext? mauiContext)
+	{
+		ArgumentNullException.ThrowIfNull(mauiContext);
+		var view = element.ToPlatform(mauiContext);
+		DragDropHelper.RegisterDrop(view);
+	}
+#endif
 
 	public static void UnRegisterDrop(this IElement element, IMauiContext? mauiContext)
 	{

--- a/MauiPaint/Message/DropItemMessage.cs
+++ b/MauiPaint/Message/DropItemMessage.cs
@@ -1,0 +1,12 @@
+﻿#if WINDOWS
+namespace MauiPaint;
+
+using CommunityToolkit.Mvvm.Messaging.Messages;
+
+public class DropItemMessage : ValueChangedMessage<Stream>
+{
+	public DropItemMessage(Stream value) : base(value)
+	{
+	}
+}
+#endif


### PR DESCRIPTION
Issue:
The Drop event did not unregister when "UnRegisterDrop" was called

Description:
As the previous [discussion](http://disq.us/p/2vhdgdu), the drop event is not unsubscribed when "unload" the page even calls "UnRegisterDrop" at "OnDisappearing" shell lifecycle methods. The main reason why is that UIElement.Drop does not unsubscribed drop event in the "UnRegisterDrop" function.

Solution:
To unregister the Drop Event, add the OnDrop function. When "RegisterDrop" is called, subscribe OnDrop event. When "UnRegisterDrop" is called, unsubscribe OnDrop event.