### PR TITLE
Fix issue were pins stay on the map when you have maps on multiple pages

### DIFF
--- a/MauiMaps/Platforms/iOS/CustomMapHandler.cs
+++ b/MauiMaps/Platforms/iOS/CustomMapHandler.cs
@@ -111,9 +111,9 @@ public class CustomMapHandler : MapHandler
 	{
 		if (handler is CustomMapHandler mapHandler)
 		{
-			foreach (var marker in mapHandler.Markers)
+			if (mapHandler.PlatformView.Annotations.Length > 0)
 			{
-				mapHandler.PlatformView.RemoveAnnotation(marker);
+				mapHandler.PlatformView.RemoveAnnotations(mapHandler.PlatformView.Annotations);
 			}
 
 			mapHandler.Markers.Clear();


### PR DESCRIPTION
Clears all the annotations prior to adding new ones. We found it was needed as of .NET 9. [Related code](https://github.com/dotnet/maui/blob/bf850e0970374f4f35c94e26f84c33cba79a668b/src/Core/maps/src/Handlers/Map/MapHandler.iOS.cs#L16). Mirrors the behaviour in [MauiMKMapView](https://github.com/dotnet/maui/blob/bf850e0970374f4f35c94e26f84c33cba79a668b/src/Core/maps/src/Platform/iOS/MauiMKMapView.cs#L120).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * On iOS, the map now clears existing annotations in bulk before re-rendering pins, preventing duplicate or outdated markers during data refreshes. This produces more reliable marker updates and smoother refresh behavior. No changes to public APIs or user interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->